### PR TITLE
Implemented 'Show Now Playing program' (EPG) functionality

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -28,7 +28,8 @@ args = dict(urlparse.parse_qsl(sys.argv[2][1:]))
 zbAddonProxy = ZBAddonProxy(kodi_addon, sys.argv[0], int(sys.argv[1]))
 zapiSession = ZapiSession(zbAddonProxy.StoragePath)
 
-if zapiSession.init_session(kodi_addon.getSetting('username'), kodi_addon.getSetting('password')):
+showNowPlayingProgram = kodi_addon.getSetting('showNowPlayingProgram') == 'true'
+if zapiSession.init_session(kodi_addon.getSetting('username'), kodi_addon.getSetting('password'), showNowPlayingProgram):
 
 	if not 'ext' in args:
 		#collect content from all extensions

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -26,6 +26,10 @@ msgctxt "#30002"
 msgid "Password"
 msgstr ""
 
+msgctxt "#30003"
+msgid "Show 'now playing' program next to channel name"
+msgstr ""
+
 msgctxt "#30100"
 msgid "LiveTV - favorites"
 msgstr ""

--- a/resources/lib/core/zapisession.py
+++ b/resources/lib/core/zapisession.py
@@ -21,6 +21,7 @@ class ZapiSession:
 	Username = None
 	Password = None
 	AccountData = None
+	ShowNowPlayingProgram = False
 
 	def __init__(self, cacheFolder):
 		if cacheFolder is not None:
@@ -31,9 +32,10 @@ class ZapiSession:
 		self.HttpHandler = urllib2.build_opener()
 		self.HttpHandler.addheaders = [('Content-type', 'application/x-www-form-urlencoded'),('Accept', 'application/json')]
 
-	def init_session(self, username, password):
+	def init_session(self, username, password, showNowPlayingProgram):
 		self.Username = username
 		self.Password = password
+		self.ShowNowPlayingProgram = showNowPlayingProgram
 		return (self.CACHE_ENABLED and self.restore_session()) or self.renew_session()
 
 	def restore_session(self):

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -3,5 +3,6 @@
     <category label="30000">
         <setting label="30001" type="text" id="username" default=""/>
         <setting label="30002" type="text" id="password" option="hidden" enable="!eq(-1,)" default=""/>
+        <setting label="30003" type="bool" id="showNowPlayingProgram" default="false"/>
     </category>
 </settings>


### PR DESCRIPTION
Hi,

Thanks for the very good plugin -- I use it daily. I did this patch for my own use, but if you find it generally useful, do feel free to pull it. I wanted to be able to show the "now playing" program along with the channel name, in a similar way as you see on zattoo.com itself, i.e. a sort of EPG (Electronic Program Guide).

The way I did it is that I added a new Boolean setting labeled "Show 'now playing' program next to channel name". By default it is False, and when this is the case, the addon behaves exactly as you coded it.

If, on the other hand, one sets it to True, then when looking at the channels list in LiveTV mode you see something like

ITV 1 London - UEFA Champions League Highlights (next: ITV News)
ITV 2 - Release the Hounds (next: The Vampire Diaries)
ITV3 - Law & Order UK (next: Cold Blood)
etc...

In this mode, the channel cache is a separate file, and it will last 4 minutes as opposed to 1 full day, because of course you want to have fresh program information.

I have tested the addon in both modes -- with the new setting off and on, and it seems to behave properly. Again, feel free to pull if you feel it's a change worthy of submitting to the main Kodi plugin repo.

(For what it's worth, and to establish a bit of credibility, I am the author of another Kodi video plugin, https://github.com/gdomenici/plugin.video.pcloud-video-streaming).

Kind regards,

Guido
