### PR TITLE
Fixes issue that Kodi 18 does not start player since ListItem type mu…

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.zattoobox"
-       version="1.0.4"
+       version="1.0.5"
        name="Zattoo Box"
        provider-name="Pascal Nançoz">
   <requires>

--- a/resources/lib/core/zbplayableitem.py
+++ b/resources/lib/core/zbplayableitem.py
@@ -20,4 +20,5 @@ class ZBPlayableItem(ZBDirectoryItem):
 	def get_listItem(self):
 		li = xbmcgui.ListItem(label=self.Title, label2=self.Title2, iconImage=self.Image)
 		li.setProperty('IsPlayable', 'true')
+		li.setInfo( type="video", infoLabels=None)
 		return li


### PR DESCRIPTION
…st be explicitly of type video

I have seen that in Kodi v18 the video does not start.

In log files it says:
20:40:53.239 T:4528 WARNING: Playlist Player: ListItem type must be audio or video, use ListItem::setInfo to specify!

Therefore I have added the setInfo method call in plugin.video.zattoobox\resources\lib\core\zbplayableitem.py which fixed the problem